### PR TITLE
Various fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ class ClematisExample:Clematis{
         EndDescribe();
 
         Describe('Testing Math');
-            It('Calculus', AssertFalse(0*1!=0), ERR_Error);
-            It('Math', AssertSame(Pointer1, Pointer2, "Custom error message"), ERR_Warning);
+            It('Calculus', AssertFalse(0*1!=0), LOG_Error);
+            It('Math', AssertSame(Pointer1, Pointer2, "Custom error message"), LOG_Warning);
         EndDescribe();
     }
 }

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ class ClematisExample:Clematis{
 
         Describe('Testing Math');
             It('Calculus', AssertFalse(0*1!=0), ERR_Error);
-            It('Math', AssertSame(Pointer1, Pointer2, "Custom error mesage"), ERR_Warning);
+            It('Math', AssertSame(Pointer1, Pointer2, "Custom error message"), ERR_Warning);
         EndDescribe();
     }
 }

--- a/src/ZSCRIPT/CLEMATIS/CLEMATIS.zsc
+++ b/src/ZSCRIPT/CLEMATIS/CLEMATIS.zsc
@@ -86,9 +86,11 @@ class Clematis abstract{
     }
 
     void It(Name TestCaseName, Cl_Assertion Assertion, Cl_ELogSeverity Severity){
-        uint DeltaTime=MSTime();
+        uint TimeBefore=MSTime();
         bool Condition=Assertion.Eval();
-        DeltaTime=DeltaTime-MSTime();
+        uint TimeAfter=MSTime();
+        uint DeltaTime=TimeAfter-TimeBefore;
+
         Cl_Result Result=Cl_Result.Create(TestCaseName, Condition, Severity, Assertion.ErrorMsg, DeltaTime);
         String Suff;
         if(Result.Success){

--- a/src/ZSCRIPT/CLEMATIS/CLEMATIS.zsc
+++ b/src/ZSCRIPT/CLEMATIS/CLEMATIS.zsc
@@ -25,7 +25,7 @@ class Clematis abstract{
      * 3. Factory method
      *     Clematis.Create('ClematisExample');
      *
-     * Otherwise one can instatiate the test and call run on it
+     * Otherwise one can instantiate the test and call run on it
      *     Clematis TestSuite=Clematis.Create('ClematisExample');
      *     TestSuite.Run();
      */

--- a/src/ZSCRIPT/CLEMATIS/COMMANDS.zsc
+++ b/src/ZSCRIPT/CLEMATIS/COMMANDS.zsc
@@ -1,8 +1,7 @@
 class ClematisTestHandler:StaticEventHandler{
     override
     void NetworkProcess(ConsoleEvent e){
-        String TestName=e.Name;
-        TestName.ToLower();
+        String TestName=e.Name.MakeLower();
         if(TestName.IndexOf("test:")!=-1)
             Clematis.Create(TestName.Mid(5));
     }

--- a/src/ZSCRIPT/CLEMATIS/UTILITIES.zsc
+++ b/src/ZSCRIPT/CLEMATIS/UTILITIES.zsc
@@ -30,10 +30,9 @@ class Cl_Util{
         if(Owner!='')
             Result="["..Owner.."] "..Result;
         LogText=Color..Result..LogText;
+        Console.PrintF(LogText);
         if(Severity==LOG_Fatal)
             ThrowAbortException(LogText);
-        else
-            Console.PrintF(LogText);
     }
 
     static


### PR DESCRIPTION
1. Fixed spelling in a couple of places (minor fix).
2. Replaced deprecated ToLower function with MakeLower (there was a warning).
3. The code from the Readme didn't compile - fixed (minor).
4. Negative time was reported for tests (I consider this important).
5. Print log message even in the case of fatal error. Sometimes useful to have this message in a log too.